### PR TITLE
Load tour css and js only when a tour is present

### DIFF
--- a/tour.php
+++ b/tour.php
@@ -14,7 +14,9 @@ defined( 'ABSPATH' ) || die();
 
 function tour_enqueue_scripts() {
 	static $once = false;
-	if ( $once ) {
+	$tours = apply_filters( 'tour_list', array() );
+
+	if ( $once || empty( $tours ) ) {
 		return;
 	}
 	$once = true;
@@ -29,7 +31,7 @@ function tour_enqueue_scripts() {
 	wp_localize_script(
 		'tour',
 		'tour_plugin', array(
-			'tours'    => apply_filters( 'tour_list', array() ),
+			'tours'    => $tours,
 			'nonce'    => wp_create_nonce( 'wp_rest' ),
 			'rest_url' => rest_url(),
 			'progress' => get_user_option( 'tour-progress', get_current_user_id() ),

--- a/tour.php
+++ b/tour.php
@@ -14,12 +14,12 @@ defined( 'ABSPATH' ) || die();
 
 function tour_enqueue_scripts() {
 	static $once = false;
-	$tours = apply_filters( 'tour_list', array() );
 
 	if ( $once ) {
 		return;
 	}
 	$once = true;
+	$tours = apply_filters( 'tour_list', array() );
 
 	if ( empty( $tours ) ) {
 		return;

--- a/tour.php
+++ b/tour.php
@@ -16,10 +16,14 @@ function tour_enqueue_scripts() {
 	static $once = false;
 	$tours = apply_filters( 'tour_list', array() );
 
-	if ( $once || empty( $tours ) ) {
+	if ( $once ) {
 		return;
 	}
 	$once = true;
+
+	if ( empty( $tours ) ) {
+		return;
+	}
 
 	wp_register_style( 'driver-js', plugins_url( 'assets/css/driver-js.css', __FILE__ ), array(), filemtime( __DIR__ . '/assets/css/driver-js.css' ) );
 	wp_register_style( 'tour-css', plugins_url( 'assets/css/style.css', __FILE__ ), array(), filemtime( __DIR__ . '/assets/css/style.css' ) );


### PR DESCRIPTION
Fixes #4.

The tour css and js files are loaded whether a tour exists or not. This PR fixes this by checking if a tour exists before loading the scripts.