### PR TITLE
Make tour list items clickable

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -40,3 +40,6 @@ ul#page-tour-list li a {
 #wp-admin-bar-tour-list {
 	display: none;
 }
+.inline-tour-list {
+	cursor: pointer;
+}

--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -213,7 +213,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 	function filter_available_tours_on_page() {
 		const tourListItems = document.querySelectorAll(
-			'#page-tour-list li a'
+			'.inline-tour-list'
 		);
 
 		if ( tourListItems ) {
@@ -228,7 +228,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 						: false;
 				if ( ! tourIsPresent ) {
 					document
-						.querySelector( 'a[data-tour-id="' + _tourId + '"]' )
+						.querySelector( '.inline-tour-list[data-tour-id="' + _tourId + '"]' )
 						.remove();
 				}
 			}

--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -212,9 +212,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	setTimeout( filter_available_tours_on_masterbar, 500 );
 
 	function filter_available_tours_on_page() {
-		const tourListItems = document.querySelectorAll(
-			'.inline-tour-list'
-		);
+		const tourListItems = document.querySelectorAll( '.inline-tour-list' );
 
 		if ( tourListItems ) {
 			for ( let i = 0; i < tourListItems.length; i++ ) {
@@ -228,7 +226,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 						: false;
 				if ( ! tourIsPresent ) {
 					document
-						.querySelector( '.inline-tour-list[data-tour-id="' + _tourId + '"]' )
+						.querySelector(
+							'.inline-tour-list[data-tour-id="' + _tourId + '"]'
+						)
 						.remove();
 				}
 			}

--- a/class-tour.php
+++ b/class-tour.php
@@ -740,7 +740,7 @@ class Tour {
 		}
 		$tour_list = '<ul id="page-tour-list">';
 		foreach ( $tours as $tour_id => $tour ) {
-			$tour_list .= '<li><span data-tour-id="' . esc_attr( $tour_id ) . '">' . esc_html( $tour[0]['title'] ) . '</span></li>';
+			$tour_list .= '<li><a class="inline-tour-list" data-tour-id="' . esc_attr( $tour_id ) . '">' . esc_html( $tour[0]['title'] ) . '</a class="page-tour-item"></li>';
 		}
 		$tour_list .= '</ul>';
 


### PR DESCRIPTION
The tour list items added via shortcode or Gutenberg block are not clickable because they are wrapped in a `<span>` tag instead of an `<a>` tag. This PR fixes this issue.