### PR TITLE
Misc fixes

### DIFF
--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -222,6 +222,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 	function filter_available_tours() {
 		const tourListItems = document.querySelectorAll( '.tour-list-item' );
+		let foundTour = false;
 
 		for ( let i = 0; i < tourListItems.length; i++ ) {
 			let tourId = tourListItems[ i ].dataset.tourId;
@@ -241,6 +242,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 				document.querySelector(
 					tour_plugin.tours[ tourId ][ 1 ].element
 				);
+			if ( tourIsPresent ) {
+				foundTour = true;
+			}
 			document
 				.querySelectorAll(
 					'.tour-list-item[data-tour-id="' +
@@ -263,6 +267,10 @@ document.addEventListener( 'DOMContentLoaded', function () {
 						).style.display = 'block';
 					}
 				} );
+		}
+
+		if ( foundTour ) {
+			loadTour();
 		}
 	}
 

--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -309,11 +309,8 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 			delete tour_plugin.progress[ tourId ];
 			loadTour();
-			pulseToClick = document.querySelector(
-				'.pulse.tour-' + tourId
-			);
+			pulseToClick = document.querySelector( '.pulse.tour-' + tourId );
 			pulseToClick.click();
-
 		}
 	} );
 } );

--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -300,22 +300,20 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			xhr.open( 'POST', tour_plugin.rest_url + 'tour/v1/save-progress' );
 			xhr.setRequestHeader( 'Content-Type', 'application/json' );
 			xhr.setRequestHeader( 'X-WP-Nonce', tour_plugin.nonce );
-			xhr.onload = function () {
-				if ( xhr.status >= 200 && xhr.status < 300 ) {
-					delete tour_plugin.progress[ tourId ];
-					loadTour();
-					pulseToClick = document.querySelector(
-						'.pulse.tour-' + tourId
-					);
-					pulseToClick.click();
-				}
-			};
 			xhr.send(
 				JSON.stringify( {
 					tour: tourId,
 					step: -1,
 				} )
 			);
+
+			delete tour_plugin.progress[ tourId ];
+			loadTour();
+			pulseToClick = document.querySelector(
+				'.pulse.tour-' + tourId
+			);
+			pulseToClick.click();
+
 		}
 	} );
 } );

--- a/class-tour.php
+++ b/class-tour.php
@@ -623,8 +623,8 @@ class Tour {
 					),
 				);
 			} elseif ( 'draft' === $tour->post_status ) {
-                $tour_steps[0]['title'] .= ' (' . _x( 'Draft', 'post status' ) . ')'; // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-            }
+				$tour_steps[0]['title'] .= ' (' . _x( 'Draft', 'post status' ) . ')'; // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			}
 			$tours[ $tour->ID ] = $tour_steps;
 		}
 

--- a/class-tour.php
+++ b/class-tour.php
@@ -618,11 +618,13 @@ class Tour {
 			if ( ! $tour_steps ) {
 				$tour_steps = array(
 					array(
-						'title' => $tour->post_title . ( 'draft' === $tour->post_status ? ' (Draft)' : '' ),
+						'title' => $tour->post_title . ( 'draft' === $tour->post_status ? ' (' . _x( 'Draft', 'post status' ) . ')' : '' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 						'color' => '#3939c7',
 					),
 				);
-			}
+			} elseif ( 'draft' === $tour->post_status ) {
+                $tour_steps[0]['title'] .= ' (' . _x( 'Draft', 'post status' ) . ')'; // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+            }
 			$tours[ $tour->ID ] = $tour_steps;
 		}
 


### PR DESCRIPTION
I've fixed a couple of small things in this PR:

When restarting a tour through the masterbar, there was a delay because we were waiting for the server response. This is not necessary, we want to show the tour right away. If it happens that the server doesn't save the progress it will have another chance when the user moves to the next step.

There was code already that added "(Draft)" to the title of a tour while it is in draft but this was only displayed when the tour had no steps. For tour creators it is good to know which tours are active.

When a tour would only become available after a short while after DOM was loaded, we did show the masterbar tour item but the pulse was missing. This runs `loadTour()` again so that the new pulses are added.