### PR TITLE
Use dedicated rest_url calls

### DIFF
--- a/assets/js/tour-step-editor.js
+++ b/assets/js/tour-step-editor.js
@@ -79,7 +79,7 @@ enableTourCreation();
 
 function reportMissingSelector( tourTitle, step, selector ) {
 	const xhr = new XMLHttpRequest();
-	xhr.open( 'POST', tour_plugin.rest_url + 'tour/v1/report-missing' );
+	xhr.open( 'POST', tour_plugin.rest_report_missing_url );
 	xhr.setRequestHeader( 'Content-Type', 'application/json' );
 	xhr.setRequestHeader( 'X-WP-Nonce', tour_plugin.nonce );
 	xhr.send(
@@ -220,7 +220,7 @@ const tourStepSelector = function ( event ) {
 
 	if ( tour_plugin.tours[ tourId ].length > 1 ) {
 		const xhr = new XMLHttpRequest();
-		xhr.open( 'POST', tour_plugin.rest_url + 'tour/v1/save' );
+		xhr.open( 'POST', tour_plugin.rest_save_url );
 		xhr.setRequestHeader( 'Content-Type', 'application/json' );
 		xhr.setRequestHeader( 'X-WP-Nonce', tour_plugin.nonce );
 		xhr.send(

--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -24,7 +24,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 		dismissTour = function () {
 			const xhr = new XMLHttpRequest();
-			xhr.open( 'POST', tour_plugin.rest_url + 'tour/v1/save-progress' );
+			xhr.open( 'POST', tour_plugin.rest_save_progress_url );
 			xhr.setRequestHeader( 'Content-Type', 'application/json' );
 			xhr.setRequestHeader( 'X-WP-Nonce', tour_plugin.nonce );
 			xhr.send(
@@ -48,10 +48,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			onHighlighted( element, step, options ) {
 				tour_plugin.progress[ tourId ] = options.state.activeIndex + 1;
 				const xhr = new XMLHttpRequest();
-				xhr.open(
-					'POST',
-					tour_plugin.rest_url + 'tour/v1/save-progress'
-				);
+				xhr.open( 'POST', tour_plugin.rest_save_progress_url );
 				xhr.setRequestHeader( 'Content-Type', 'application/json' );
 				xhr.setRequestHeader( 'X-WP-Nonce', tour_plugin.nonce );
 				xhr.send(
@@ -66,10 +63,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 					addPulse( tourId, options.state.activeIndex + 1 );
 				} else {
 					const xhr = new XMLHttpRequest();
-					xhr.open(
-						'POST',
-						tour_plugin.rest_url + 'tour/v1/save-progress'
-					);
+					xhr.open( 'POST', tour_plugin.rest_save_progress_url );
 					xhr.setRequestHeader( 'Content-Type', 'application/json' );
 					xhr.setRequestHeader( 'X-WP-Nonce', tour_plugin.nonce );
 					xhr.send(
@@ -297,7 +291,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			pulseToClick.click();
 		} else {
 			const xhr = new XMLHttpRequest();
-			xhr.open( 'POST', tour_plugin.rest_url + 'tour/v1/save-progress' );
+			xhr.open( 'POST', tour_plugin.rest_save_progress_url );
 			xhr.setRequestHeader( 'Content-Type', 'application/json' );
 			xhr.setRequestHeader( 'X-WP-Nonce', tour_plugin.nonce );
 			xhr.send(

--- a/class-tour.php
+++ b/class-tour.php
@@ -60,10 +60,12 @@ class Tour {
 			'tour',
 			'tour_plugin',
 			array(
-				'tours'    => $tours,
-				'nonce'    => wp_create_nonce( 'wp_rest' ),
-				'rest_url' => rest_url(),
-				'progress' => get_user_option( 'tour-progress', get_current_user_id() ),
+				'tours'                   => $tours,
+				'nonce'                   => wp_create_nonce( 'wp_rest' ),
+				'rest_save_progress_url'  => rest_url( 'tour/v1/save-progress' ),
+				'rest_report_missing_url' => rest_url( 'tour/v1/report-missing' ),
+				'rest_save_url'           => rest_url( 'tour/v1/save' ),
+				'progress'                => get_user_option( 'tour-progress', get_current_user_id() ),
 			)
 		);
 
@@ -712,7 +714,7 @@ class Tour {
 		event.preventDefault();
 
 		var xhr = new XMLHttpRequest();
-		xhr.open('POST', tour_plugin.rest_url + 'tour/v1/save-progress');
+		xhr.open('POST', tour_plugin.rest_save_progress_url );
 		xhr.setRequestHeader('Content-Type', 'application/json');
 		xhr.setRequestHeader('X-WP-Nonce', tour_plugin.nonce);
 		xhr.send(JSON.stringify({


### PR DESCRIPTION
For environments where the REST URL can vary based on the endpoint, we need to pass through the single URLs.