### PR TITLE
Commit `.wp-env.json` file so that `wp-env` can be used to spin up a dev environment

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,5 @@
+{
+  "core": "WordPress/WordPress",
+  "phpVersion": "7.4",
+  "plugins": [ "." ]
+}


### PR DESCRIPTION
This PR adds support for [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)