### PR TITLE
Rephrase dismiss text

### DIFF
--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -43,7 +43,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			steps: tourSteps,
 			onHighlightStarted( element, step ) {
 				step.popover.description +=
-					'<br><button class="dismiss-tour">Dismiss the tour';
+					'<br><button class="dismiss-tour">Do not show this again';
 			},
 			onHighlighted( element, step, options ) {
 				tour_plugin.progress[ tourId ] = options.state.activeIndex + 1;


### PR DESCRIPTION
![Screenshot 2024-02-06 at 16 07 20](https://github.com/Automattic/tour/assets/858906/d2ba6f50-21db-4d90-971a-cf9360b3fb5f)

Since the intent behind `Dimiss the tour` link/action is to suppress the tour completely, permanent-ness of which isn't conveyed to the user, I suggest renaming it to `Do not show this again`, which conveys the difference between choosing that over `X` to close it.

