### PR TITLE
Update plugin name to tours

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tour
+# Tours
 
 - Contributors: akirk, amieiro, psrpinto, spiraltee
 - Tags: tour
@@ -12,7 +12,7 @@ Create tours for your site, these tours can be activated by the user by clicking
 
 ## Description
 
-Tour is a plugin that allows you to create tours for your site. They can be activated by the user by clicking colored glowing buttons.
+Tours is a plugin that allows you to create tours for your site. They can be activated by the user by clicking colored glowing buttons.
 
 Creating the tour is done by entering a creation mode where the HTML tag to be used is highlighted. You can then enter the text for the step, and create a new step by clicking on the next tag to be highlighted.
 

--- a/class-tour.php
+++ b/class-tour.php
@@ -636,7 +636,7 @@ class Tour {
 	 * Adds the tour menu to the sidebar.
 	 */
 	public static function add_admin_menu() {
-		add_menu_page( 'Tour', 'Tour', 'edit_posts', 'tour', 'tour', 'dashicons-admin-site-alt3', 6 );
+		add_menu_page( 'Tours', 'Tours', 'edit_posts', 'tour', 'tour', 'dashicons-admin-site-alt3', 6 );
 		add_submenu_page( 'tour', 'Settings', 'Settings', 'edit_posts', 'tour-settings', array( get_called_class(), 'tour_admin_settings' ) );
 	}
 

--- a/tour.php
+++ b/tour.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: Tour
- * Plugin URI: http://wordpress.org/plugins/tour/
+ * Plugin Name: Tours
+ * Plugin URI: http://wordpress.org/plugins/tours/
  * Description: A WordPress plugin for creating tours for your site.
  * Version: 1.0.0
  * Author: Automattic


### PR DESCRIPTION
Due to this error(see below) encountered when trying to upload the plugin to the plugin directory;
`Error: The plugin slug is too short. Your chosen plugin name - tour - is not permitted because it is too short. Please change the Plugin Name: line in your main plugin file and readme to a different name. When you have finished, you may upload your plugin again.`

We decided to change the name to `Tours`


