### PR TITLE
Replace tour with tours

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tours
 
 - Contributors: akirk, amieiro, psrpinto, spiraltee
-- Tags: tour
+- Tags: tours
 - Requires at least: 5.0
 - Tested up to: 6.5
 - Requires PHP: 5.6

--- a/class-tours.php
+++ b/class-tours.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * @package Tour
+ * @package Tours
  */
 
 /**
  * The class containting all hooks for the Tour.
  */
-class Tour {
+class Tours {
 	/**
 	 * Register all hooks.
 	 */

--- a/tours.php
+++ b/tours.php
@@ -6,14 +6,14 @@
  * Version: 1.0.0
  * Author: Automattic
  * Author URI: http://automattic.com/
- * Text Domain: tour
+ * Text Domain: tours
  * License: GPLv2 or later
  *
  * @package Tour
  */
 
 defined( 'ABSPATH' ) || die();
-define( 'TOUR_VERSION', '1.0' );
+define( 'TOURS_VERSION', '1.0' );
 
-require __DIR__ . '/class-tour.php';
-Tour::register_hooks();
+require __DIR__ . '/class-tours.php';
+Tours::register_hooks();


### PR DESCRIPTION
The slug of the plugin in the WordPress directory would be`tours` so in this PR I renamed some instances of `tour` to `tours` to make it not confusing.