### PR TITLE
Add video url to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Creating the tour is done by entering a creation mode where the HTML tag to be u
 
 
 
-https://github.com/Automattic/tours/assets/203408/783bb967-2907-45b8-8bd9-da7f32147ea0
+https://github-production-user-asset-6210df.s3.amazonaws.com/203408/285230212-783bb967-2907-45b8-8bd9-da7f32147ea0.mp4
 
 
 
@@ -33,8 +33,7 @@ https://github.com/Automattic/tours/assets/203408/783bb967-2907-45b8-8bd9-da7f32
 
 
 
-
-https://github.com/Automattic/tours/assets/203408/be7f56d6-3869-4afb-9393-242312306180
+https://github-production-user-asset-6210df.s3.amazonaws.com/203408/285230384-be7f56d6-3869-4afb-9393-242312306180.mp4
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Create tours for your site, these tours can be activated by the user by clicking
 
 Tours is a plugin that allows you to create tours for your site. They can be activated by the user by clicking colored glowing buttons.
 
-
 Creating the tour is done by entering a creation mode where the HTML tag to be used is highlighted. You can then enter the text for the step, and create a new step by clicking on the next tag to be highlighted.
 
 ## Installation
@@ -24,15 +23,11 @@ Creating the tour is done by entering a creation mode where the HTML tag to be u
 
 ### Going through a Tour
 
-
 https://vimeo.com/953923601
-
-
 
 ### Creating a Tour
 
-https://vimeo.com/953923624?share=copy
-
+https://vimeo.com/953923624
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -14,26 +14,25 @@ Create tours for your site, these tours can be activated by the user by clicking
 
 Tours is a plugin that allows you to create tours for your site. They can be activated by the user by clicking colored glowing buttons.
 
+
 Creating the tour is done by entering a creation mode where the HTML tag to be used is highlighted. You can then enter the text for the step, and create a new step by clicking on the next tag to be highlighted.
 
 ## Installation
 
 1. Upload the `tours` directory to the `/wp-content/plugins/` directory
-1. Activate the plugin through the 'Plugins' menu in WordPress
+2. Activate the plugin through the 'Plugins' menu in WordPress
 
 ### Going through a Tour
 
 
-
-https://github-production-user-asset-6210df.s3.amazonaws.com/203408/285230212-783bb967-2907-45b8-8bd9-da7f32147ea0.mp4
+https://vimeo.com/953923601
 
 
 
 ### Creating a Tour
 
+https://vimeo.com/953923624?share=copy
 
-
-https://github-production-user-asset-6210df.s3.amazonaws.com/203408/285230384-be7f56d6-3869-4afb-9393-242312306180.mp4
 
 ## Credits
 


### PR DESCRIPTION
We have two videos that explains how to use the tour plugins and we want to have it embedded in the plugin's README. In this PR we add the video url (.mp4) to the README.